### PR TITLE
Remove Non-Roles

### DIFF
--- a/01_roles/en.yml
+++ b/01_roles/en.yml
@@ -192,9 +192,3 @@ terms:
   - vanilla:
       name: Vanilla
       definition: A person with without any identified kinks or fetishes.
-  - undecided:
-      name: Undecided
-      definition: A person who doesn’t currently identify with a particular role.
-  - not_applicable:
-      name: Not Applicable
-      definition: A person who doesn’t want to specify a particular role.


### PR DESCRIPTION
I don't consider undecided and not applicable to be roles.  I suggest we remove them from our glossary.