### PR TITLE
Update definition of `Demisexual`

### DIFF
--- a/03_orientations/en.yml
+++ b/03_orientations/en.yml
@@ -32,7 +32,7 @@ terms:
       definition: A person who has low or absent sexual interest or desire for people of any gender.
   - demisexual:
       name: Demisexual
-      description: A person who does not experience sexual attraction unless they form a strong emotional connection with someone. Demisexual falls under the asexual umbrella.
+      description: A person who does not experience sexual attraction unless they form a strong emotional connection with someone. The term demisexual comes from the orientation being "halfway between" sexual and asexual.
   - greysexual:
       name: Greysexual
       description: A person who experiences sexual attraction under very limited and specific circumstances. Greysexual is sometimes referred to as grey-asexual and falls under the asexual umbrella.

--- a/03_orientations/en.yml
+++ b/03_orientations/en.yml
@@ -27,15 +27,15 @@ terms:
   - pansexual:
       name: Pansexual
       definition: A person who is attracted to and may form sexual and romantic relationships with males, females, and people who identify outside the gender binary.
-  - asexual:
-      name: Asexual
-      definition: A person who has low or absent sexual interest or desire for people of any gender.
   - demisexual:
       name: Demisexual
       description: A person who does not experience sexual attraction unless they form a strong emotional connection with someone. The term demisexual comes from the orientation being "halfway between" sexual and asexual.
+  - asexual:
+      name: Asexual
+      definition: A person who has low or absent sexual interest or desire for people of any gender.
   - greysexual:
       name: Greysexual
-      description: A person who experiences sexual attraction under very limited and specific circumstances. Greysexual is sometimes referred to as grey-asexual and falls under the asexual umbrella.
+      description: A person who experiences sexual attraction under very limited and specific circumstances.
   - sapiosexual:
       name: Sapiosexual
       description: A person who is sexually attracted to someone’s intelligence.


### PR DESCRIPTION
I removed the second part of the definition i.e. I removed:

> Demisexual falls under the asexual umbrella.

Even though it might be true that `Demisexual` falls under the asexual umbrella, I don't think it adds much value to the definition at this point. That statement is more interesting for people who are interested in the study or sexual orientations, not someone who's trying to figure out who they are. 

While making that change I also decided to:

- Made the same change to `Greysexual`, for the same reasons
- Moved definition of `Demisexual` above `Asexual` so the order is similar to our sexual orientation list

*P.S. A separate feature spec was created to add `Demisexual` to our list of features. So it should be added shortly.*

