### PR TITLE
Remove "primarily" from the definition of gay and lesbian

### DIFF
--- a/03_orientations/en.yml
+++ b/03_orientations/en.yml
@@ -17,10 +17,10 @@ terms:
       definition: A person who identifies as primarily homosexual but can occasionally find the opposite gender appealing in a sexual and/or romantic way.
   - gay:
       name: Gay
-      definition: A male who is primarily attracted to other males in a sexual and/or romantic way.
+      definition: A male who is attracted to other males in a sexual and/or romantic way.
   - lesbian:
       name: Lesbian
-      definition: A female who is primarily attracted to other females in a sexual and/or romantic way.
+      definition: A female who is attracted to other females in a sexual and/or romantic way.
   - queer:
       name: Queer
       definition: A person who doesn't identify with traditional categories around gender identity and sexual orientation.


### PR DESCRIPTION
Make the definitions of gay and lesbian consistent with the definition of straight by removing "primarily" from the definitions of gay and lesbian.